### PR TITLE
use environment vars

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+REACT_APP_GRAPHQL_API_URL=http://localhost:4000/

--- a/src/services/ApolloClient.ts
+++ b/src/services/ApolloClient.ts
@@ -1,5 +1,5 @@
 import ApolloClient from "apollo-boost";
 
 export default new ApolloClient({
-  uri: "http://localhost:4000/"
+  uri: process.env.REACT_APP_GRAPHQL_API_URL
 });


### PR DESCRIPTION
### Related tickets:
- https://jira.amida.com/browse/LAD-11
### What's changing? Any breaking changes?
- No breaking changes. Allows us to configure the graphql endpoint with environment variables

### Manual test cases?
- Start mockserver `cd mock-server && yarn && yarn start`
- navigate to `/app/rating` and make sure it successfully makes a request to the mock api

### Any additional context/background?
-

### Screenshots (if appropriate):
-
